### PR TITLE
Correctness & security fixes: LIKE ESCAPE, UTF-8 truncation, pagination overflow, scoped errors, partial-delete leak, validation, 409, auto-validate

### DIFF
--- a/crudcrate-derive/src/codegen/handlers/create.rs
+++ b/crudcrate-derive/src/codegen/handlers/create.rs
@@ -10,10 +10,22 @@ use quote::quote;
 /// - `create::one::transform`: Modify the result (receives `Self`, returns `Self`)
 /// - `create::one::post`: Side effects after create (receives `&Self`)
 pub fn generate_create_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenStream {
+    // Auto-validation: runs `Validatable::validate` when the CreateModel implements it,
+    // and is a no-op otherwise (autoref specialization in `crudcrate::validation::__auto`).
+    let validate = quote! {
+        {
+            use crudcrate::validation::__auto::ValidatableFallback as _;
+            crudcrate::validation::__auto::Probe(&data)
+                .crudcrate_auto_validate()
+                .map_err(crudcrate::ApiError::from)?;
+        }
+    };
+
     // If operations is specified, use it (takes full control)
     if let Some(ops_path) = &crud_meta.operations {
         return quote! {
             async fn create(db: &sea_orm::DatabaseConnection, data: Self::CreateModel) -> Result<Self, crudcrate::ApiError> {
+                #validate
                 let ops = #ops_path;
                 crudcrate::CRUDOperations::create(&ops, db, data).await
             }
@@ -51,6 +63,7 @@ pub fn generate_create_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenS
 
     quote! {
         async fn create(db: &sea_orm::DatabaseConnection, data: Self::CreateModel) -> Result<Self, crudcrate::ApiError> {
+            #validate
             #pre_hook
             #body
             #transform_hook
@@ -71,10 +84,24 @@ pub fn generate_create_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenS
 /// **Security Note**: The default implementation limits batch creates to 100 items to prevent
 /// `DoS` attacks via resource exhaustion.
 pub fn generate_create_many_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenStream {
+    // Auto-validation: validate every item before any insert (no-op for CreateModels
+    // that don't implement Validatable). See `crudcrate::validation::__auto`.
+    let validate = quote! {
+        {
+            use crudcrate::validation::__auto::ValidatableFallback as _;
+            for __cc_item in &data {
+                crudcrate::validation::__auto::Probe(__cc_item)
+                    .crudcrate_auto_validate()
+                    .map_err(crudcrate::ApiError::from)?;
+            }
+        }
+    };
+
     // If operations is specified, use it (takes full control)
     if let Some(ops_path) = &crud_meta.operations {
         return quote! {
             async fn create_many(db: &sea_orm::DatabaseConnection, data: Vec<Self::CreateModel>) -> Result<Vec<Self>, crudcrate::ApiError> {
+                #validate
                 let ops = #ops_path;
                 crudcrate::CRUDOperations::create_many(&ops, db, data).await
             }
@@ -133,6 +160,7 @@ pub fn generate_create_many_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::T
 
     quote! {
         async fn create_many(db: &sea_orm::DatabaseConnection, data: Vec<Self::CreateModel>) -> Result<Vec<Self>, crudcrate::ApiError> {
+            #validate
             #pre_hook
             #body
             #transform_hook

--- a/crudcrate-derive/src/codegen/handlers/delete.rs
+++ b/crudcrate-derive/src/codegen/handlers/delete.rs
@@ -131,8 +131,11 @@ pub fn generate_delete_many_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::T
                         .await?;
                 }
 
-                // Return only IDs that actually existed (preserving input order)
-                ids.into_iter().filter(|id| existing_set.contains(id)).collect()
+                // Return only IDs that actually existed, de-duplicated while preserving
+                // input order. The DELETE is de-duplicated via existing_set, so echoing
+                // duplicate input ids would over-report the rows actually deleted.
+                let mut seen = std::collections::HashSet::new();
+                ids.into_iter().filter(|id| existing_set.contains(id) && seen.insert(*id)).collect()
             };
         }
     };

--- a/crudcrate-derive/src/codegen/handlers/update.rs
+++ b/crudcrate-derive/src/codegen/handlers/update.rs
@@ -9,10 +9,22 @@ use quote::quote;
 /// - `update::one::transform`: Modify the result (receives `Self`, returns `Self`)
 /// - `update::one::post`: Side effects after update (receives `&Self`)
 pub fn generate_update_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenStream {
+    // Auto-validation: runs `Validatable::validate` when the UpdateModel implements it,
+    // and is a no-op otherwise (autoref specialization in `crudcrate::validation::__auto`).
+    let validate = quote! {
+        {
+            use crudcrate::validation::__auto::ValidatableFallback as _;
+            crudcrate::validation::__auto::Probe(&data)
+                .crudcrate_auto_validate()
+                .map_err(crudcrate::ApiError::from)?;
+        }
+    };
+
     // If operations is specified, use it (takes full control)
     if let Some(ops_path) = &crud_meta.operations {
         return quote! {
             async fn update(db: &sea_orm::DatabaseConnection, id: uuid::Uuid, data: Self::UpdateModel) -> Result<Self, crudcrate::ApiError> {
+                #validate
                 let ops = #ops_path;
                 crudcrate::CRUDOperations::update(&ops, db, id, data).await
             }
@@ -61,6 +73,7 @@ pub fn generate_update_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenS
 
     quote! {
         async fn update(db: &sea_orm::DatabaseConnection, id: uuid::Uuid, data: Self::UpdateModel) -> Result<Self, crudcrate::ApiError> {
+            #validate
             #pre_hook
             #body
             #transform_hook
@@ -80,10 +93,24 @@ pub fn generate_update_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenS
 /// **Security Note**: The default implementation limits batch updates to 100 items to prevent
 /// `DoS` attacks via resource exhaustion.
 pub fn generate_update_many_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::TokenStream {
+    // Auto-validation: validate every update model before any write (no-op for
+    // UpdateModels that don't implement Validatable). See `crudcrate::validation::__auto`.
+    let validate = quote! {
+        {
+            use crudcrate::validation::__auto::ValidatableFallback as _;
+            for (_, __cc_item) in &updates {
+                crudcrate::validation::__auto::Probe(__cc_item)
+                    .crudcrate_auto_validate()
+                    .map_err(crudcrate::ApiError::from)?;
+            }
+        }
+    };
+
     // If operations is specified, use it (takes full control)
     if let Some(ops_path) = &crud_meta.operations {
         return quote! {
             async fn update_many(db: &sea_orm::DatabaseConnection, updates: Vec<(uuid::Uuid, Self::UpdateModel)>) -> Result<Vec<Self>, crudcrate::ApiError> {
+                #validate
                 let ops = #ops_path;
                 crudcrate::CRUDOperations::update_many(&ops, db, updates).await
             }
@@ -147,6 +174,7 @@ pub fn generate_update_many_impl(crud_meta: &CRUDResourceMeta) -> proc_macro2::T
 
     quote! {
         async fn update_many(db: &sea_orm::DatabaseConnection, updates: Vec<(uuid::Uuid, Self::UpdateModel)>) -> Result<Vec<Self>, crudcrate::ApiError> {
+            #validate
             #pre_hook
             #body
             #transform_hook

--- a/crudcrate/src/core/crud_operations.rs
+++ b/crudcrate/src/core/crud_operations.rs
@@ -103,12 +103,12 @@ macro_rules! crud_handlers_impl {
                 // Atomic scoped fetch: ID + scope condition in a single query.
                 // Prevents TOCTOU race where scope-relevant columns could change
                 // between a fetch and a separate verification query.
+                // get_one_scoped already returns NotFound (404) when the scope condition
+                // excludes the row, so existence stays masked. Propagate the real error
+                // instead of rewriting everything to 404 — genuine DB/internal faults
+                // must surface as 500 (and be logged), not masquerade as a missing row.
                 let result = <$resource as crudcrate::traits::CRUDResource>::get_one_scoped(&db, id, &extra)
-                    .await
-                    .map_err(|_| crudcrate::ApiError::not_found(
-                        <$resource as crudcrate::traits::CRUDResource>::RESOURCE_NAME_SINGULAR,
-                        Some(id.to_string()),
-                    ))?;
+                    .await?;
 
                 let response: $response_model = result.into();
                 let scoped: $scoped_response = response.into();
@@ -398,9 +398,13 @@ macro_rules! crud_handlers_impl {
                 if profile.expose_deleted_ids {
                     (status, axum::Json(result)).into_response()
                 } else {
+                    // expose_deleted_ids=false must also hide WHICH ids failed: each
+                    // per-item not-found error embeds the (missing) UUID, so serializing
+                    // `failed` verbatim would be an existence-enumeration oracle — the very
+                    // side-channel the non-partial path collapses to `{deleted: count}`.
                     let secure = serde_json::json!({
                         "succeeded_count": result.succeeded.len(),
-                        "failed": result.failed,
+                        "failed_count": result.failed.len(),
                     });
                     (status, axum::Json(secure)).into_response()
                 }
@@ -487,12 +491,20 @@ macro_rules! crud_handlers_impl {
             }
 
             if options.partial {
-                // Partial success mode: process each item individually
+                // Partial success mode: process each item individually.
+                // Use create_many with a single-item batch (not the single `create`,
+                // which on the derive path re-fetches via get_one and applies join
+                // loading + read::one::transform). This keeps the partial response the
+                // same flat shape as the all-or-nothing path below (which calls
+                // create_many) and runs the same create::many hooks for both modes.
                 let mut result: crudcrate::BatchResult<$response_model> = crudcrate::BatchResult::new();
 
                 for (index, create_model) in data.into_iter().enumerate() {
-                    match <$resource as crudcrate::traits::CRUDResource>::create(&state.0, create_model).await {
-                        Ok(created) => result.add_success(created.into()),
+                    match <$resource as crudcrate::traits::CRUDResource>::create_many(&state.0, vec![create_model]).await {
+                        Ok(mut created) => match created.pop() {
+                            Some(item) => result.add_success(item.into()),
+                            None => result.add_failure(index, "create produced no row".to_string()),
+                        },
                         Err(e) => result.add_failure(index, e.to_string()),
                     }
                 }

--- a/crudcrate/src/core/traits.rs
+++ b/crudcrate/src/core/traits.rs
@@ -297,10 +297,14 @@ where
                 .map_err(ApiError::database)?;
         }
 
-        // Return only IDs that actually existed (preserving input order)
+        // Return only IDs that actually existed, de-duplicated while preserving input
+        // order. The DELETE itself is de-duplicated via `existing_set`, so echoing a
+        // duplicated input id (e.g. [a, a]) would over-report the rows actually deleted
+        // — both as the `{deleted: count}` integer and the returned array.
+        let mut seen = std::collections::HashSet::new();
         Ok(ids
             .into_iter()
-            .filter(|id| existing_set.contains(id))
+            .filter(|id| existing_set.contains(id) && seen.insert(*id))
             .collect())
     }
 

--- a/crudcrate/src/errors.rs
+++ b/crudcrate/src/errors.rs
@@ -264,6 +264,16 @@ impl ApiError {
     /// ```
     #[must_use]
     pub fn database(err: DbErr) -> Self {
+        // A unique-constraint violation is a client error (409), not an opaque 500.
+        // The generated create/update handlers wrap insert/update errors via this
+        // function (`.map_err(ApiError::database)`) and return `Result<_, ApiError>`,
+        // so the `From<DbErr>` impl is bypassed on those paths — the mapping must live
+        // here too for the documented 409 "Duplicate record" response to be reachable.
+        if let Some(sea_orm::SqlErr::UniqueConstraintViolation(_)) = err.sql_err() {
+            return Self::Conflict {
+                message: "A record with these details already exists".to_string(),
+            };
+        }
         Self::Database {
             message: "A database error occurred".to_string(),
             internal: err,
@@ -476,6 +486,15 @@ impl std::error::Error for ApiError {}
 /// ```
 impl From<DbErr> for ApiError {
     fn from(err: DbErr) -> Self {
+        // A unique-constraint violation is a client error (409), not an opaque
+        // 500. sea-orm normalises the driver-specific signal (Postgres SQLSTATE
+        // 23505, SQLite "UNIQUE constraint failed", etc.) into `SqlErr`, so this
+        // detection is database-agnostic. We don't reflect the raw driver text.
+        if let Some(sea_orm::SqlErr::UniqueConstraintViolation(_)) = err.sql_err() {
+            return Self::Conflict {
+                message: "A record with these details already exists".to_string(),
+            };
+        }
         match &err {
             DbErr::RecordNotFound(msg) => {
                 // Try to extract resource name from error message. Only accept
@@ -501,6 +520,17 @@ impl From<DbErr> for ApiError {
                 message: "A database error occurred".to_string(),
                 internal: err,
             },
+        }
+    }
+}
+
+/// A failed [`crate::validation::Validatable::validate`] maps to 422 Unprocessable
+/// Entity. The field/message are safe to surface (they come from the application's
+/// own validation logic, not the database driver).
+impl From<crate::validation::ValidationError> for ApiError {
+    fn from(err: crate::validation::ValidationError) -> Self {
+        Self::ValidationFailed {
+            errors: vec![err.to_string()],
         }
     }
 }

--- a/crudcrate/src/filtering/conditions.rs
+++ b/crudcrate/src/filtering/conditions.rs
@@ -1,11 +1,11 @@
 use sea_orm::{
     Condition, DatabaseBackend,
-    sea_query::{Alias, Expr, ExprTrait, SimpleExpr},
+    sea_query::{Alias, Expr, ExprTrait, LikeExpr, SimpleExpr},
 };
 use std::collections::HashMap;
 use uuid::Uuid;
 
-use super::search::{build_fulltext_condition, build_like_condition};
+use super::search::{build_fulltext_condition, build_like_condition, escape_like_wildcards};
 
 // Basic safety limits
 const MAX_FIELD_VALUE_LENGTH: usize = 10_000;
@@ -23,15 +23,6 @@ const MAX_OFFSET: u64 = 1_000_000;
 /// deliberately does *not* silently drop filters, because a silently-unfiltered
 /// response is worse than a failed request.
 const MAX_FILTER_CLAUSES: usize = 100;
-
-/// Escape LIKE wildcards to prevent wildcard injection attacks
-/// Escapes: % (match any) and _ (match single char)
-fn escape_like_wildcards(input: &str) -> String {
-    input
-        .replace('\\', "\\\\") // Escape backslash first
-        .replace('%', "\\%") // Escape %
-        .replace('_', "\\_") // Escape _
-}
 
 /// Basic field name validation
 fn is_valid_field_name(field_name: &str) -> bool {
@@ -158,7 +149,10 @@ fn handle_fulltext_search<T: crate::traits::CRUDResource>(
                             SimpleExpr::FunctionCall(sea_orm::sea_query::Func::upper(
                                 Expr::cast_as(Expr::col(*col), Alias::new("TEXT")),
                             ))
-                            .like(format!("%{}%", escaped_query.to_uppercase())),
+                            .like(
+                                LikeExpr::new(format!("%{}%", escaped_query.to_uppercase()))
+                                    .escape('!'),
+                            ),
                         );
                     }
                     _ => {
@@ -167,7 +161,10 @@ fn handle_fulltext_search<T: crate::traits::CRUDResource>(
                             SimpleExpr::FunctionCall(sea_orm::sea_query::Func::upper(Expr::col(
                                 *col,
                             )))
-                            .like(format!("%{}%", escaped_query.to_uppercase())),
+                            .like(
+                                LikeExpr::new(format!("%{}%", escaped_query.to_uppercase()))
+                                    .escape('!'),
+                            ),
                         );
                     }
                 }
@@ -181,7 +178,7 @@ fn handle_fulltext_search<T: crate::traits::CRUDResource>(
                         Expr::col(*col),
                         Alias::new(cast_type),
                     )))
-                    .like(format!("%{}%", escaped_query.to_uppercase())),
+                    .like(LikeExpr::new(format!("%{}%", escaped_query.to_uppercase())).escape('!')),
                 );
             }
         }
@@ -404,7 +401,7 @@ where
                 FilterOperator::Lte => Some(col().lte(trimmed)),
                 FilterOperator::Like => {
                     let escaped = escape_like_wildcards(trimmed);
-                    Some(col().like(format!("%{escaped}%")))
+                    Some(col().like(LikeExpr::new(format!("%{escaped}%")).escape('!')))
                 }
                 FilterOperator::In | FilterOperator::IsNull => None,
             }
@@ -559,7 +556,12 @@ pub fn parse_pagination(params: &crate::models::FilterOptions) -> (u64, u64) {
     } else if let Some(range) = &params.range {
         // React Admin pagination
         let (start, end) = parse_range(Some(range.clone()));
-        let limit = (end.saturating_sub(start) + 1).min(MAX_PAGE_SIZE);
+        // saturating_add: a client-supplied end of u64::MAX would otherwise overflow
+        // the `+ 1` (panic in debug/test, silent wrap-to-zero in release).
+        let limit = end
+            .saturating_sub(start)
+            .saturating_add(1)
+            .min(MAX_PAGE_SIZE);
         let safe_start = start.min(MAX_OFFSET);
         (safe_start, limit)
     } else {
@@ -815,16 +817,288 @@ mod tests {
         assert_eq!(parse_comparison_operator("age"), None);
     }
 
-    /// Test wildcard escaping for LIKE queries
+    /// The LIKE paths in this module share search.rs's `!`-based escaper, which is
+    /// always paired with an explicit `ESCAPE '!'` clause (see
+    /// `test_build_comparison_expr_like_escapes_wildcards`). Backslash escaping was
+    /// removed because it is a no-op on SQLite (`.like()` emits no ESCAPE clause).
     #[test]
     fn test_escape_like_wildcards() {
         assert_eq!(escape_like_wildcards("normal text"), "normal text");
-        assert_eq!(escape_like_wildcards("test%"), "test\\%");
-        assert_eq!(escape_like_wildcards("test_value"), "test\\_value");
-        assert_eq!(escape_like_wildcards("%_"), "\\%\\_");
-        assert_eq!(escape_like_wildcards("\\"), "\\\\");
-        assert_eq!(escape_like_wildcards("\\%"), "\\\\\\%");
-        assert_eq!(escape_like_wildcards("100% complete"), "100\\% complete");
+        assert_eq!(escape_like_wildcards("test%"), "test!%");
+        assert_eq!(escape_like_wildcards("test_value"), "test!_value");
+        assert_eq!(escape_like_wildcards("%_"), "!%!_");
+        assert_eq!(escape_like_wildcards("!"), "!!");
+        assert_eq!(escape_like_wildcards("100% complete"), "100!% complete");
+    }
+
+    // ========================================================================
+    // build_comparison_expr — direct coverage of the public joined-filter
+    // expression builder used by derive-generated resolve_joined_filters.
+    // ========================================================================
+
+    mod cmp_entity {
+        use sea_orm::entity::prelude::*;
+
+        #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+        #[sea_orm(table_name = "cmp_things")]
+        pub struct Model {
+            #[sea_orm(primary_key)]
+            pub id: i32,
+            pub name: String,
+        }
+
+        #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+        pub enum Relation {}
+
+        impl ActiveModelBehavior for ActiveModel {}
+    }
+
+    use crate::filtering::joined::FilterOperator;
+
+    /// Render an expression to inlined SQLite SQL so the ESCAPE clause and the
+    /// (escaped) bound pattern are both visible as text.
+    fn cmp_sql(expr: SimpleExpr) -> String {
+        use sea_orm::sea_query::{Query, SqliteQueryBuilder};
+        Query::select()
+            .column(cmp_entity::Column::Id)
+            .from(cmp_entity::Entity)
+            .and_where(expr)
+            .to_string(SqliteQueryBuilder)
+    }
+
+    /// A1 regression: the joined `_like` path must escape user wildcards with `!`
+    /// AND declare `ESCAPE '!'` so the escaping is not a no-op on SQLite.
+    #[test]
+    fn test_build_comparison_expr_like_escapes_wildcards() {
+        let expr = build_comparison_expr(
+            cmp_entity::Column::Name,
+            FilterOperator::Like,
+            &serde_json::json!("100%"),
+        )
+        .expect("Like on a string builds an expression");
+        let sql = cmp_sql(expr);
+        assert!(
+            sql.contains("ESCAPE '!'"),
+            "LIKE must declare ESCAPE '!': {sql}"
+        );
+        assert!(
+            sql.contains("100!%"),
+            "user-supplied wildcard must be escaped with !: {sql}"
+        );
+    }
+
+    #[test]
+    fn test_build_comparison_expr_string_ops_build() {
+        for op in [
+            FilterOperator::Eq,
+            FilterOperator::Neq,
+            FilterOperator::Gt,
+            FilterOperator::Gte,
+            FilterOperator::Lt,
+            FilterOperator::Lte,
+        ] {
+            assert!(
+                build_comparison_expr(cmp_entity::Column::Name, op, &serde_json::json!("abc"))
+                    .is_some(),
+                "string {op:?} should build an expression"
+            );
+        }
+    }
+
+    #[test]
+    fn test_build_comparison_expr_empty_and_overlong_string_none() {
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!("")
+            )
+            .is_none()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!("   "),
+            )
+            .is_none()
+        );
+        let overlong = "a".repeat(10_001);
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!(overlong),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_build_comparison_expr_uuid_only_eq_neq() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!(uuid)
+            )
+            .is_some()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Neq,
+                &serde_json::json!(uuid)
+            )
+            .is_some()
+        );
+        // Ranges and LIKE on a UUID are meaningless -> None.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Gt,
+                &serde_json::json!(uuid)
+            )
+            .is_none()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Like,
+                &serde_json::json!(uuid)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_build_comparison_expr_number_ops_and_rejections() {
+        for op in [
+            FilterOperator::Eq,
+            FilterOperator::Neq,
+            FilterOperator::Gt,
+            FilterOperator::Gte,
+            FilterOperator::Lt,
+            FilterOperator::Lte,
+        ] {
+            assert!(
+                build_comparison_expr(cmp_entity::Column::Id, op, &serde_json::json!(42)).is_some()
+            );
+            assert!(
+                build_comparison_expr(cmp_entity::Column::Id, op, &serde_json::json!(3.5))
+                    .is_some()
+            );
+        }
+        // In / IsNull are not valid against a scalar number -> None.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Id,
+                FilterOperator::In,
+                &serde_json::json!(42)
+            )
+            .is_none()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Id,
+                FilterOperator::IsNull,
+                &serde_json::json!(42),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_build_comparison_expr_bool_eq_neq_only() {
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!(true)
+            )
+            .is_some()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Neq,
+                &serde_json::json!(false),
+            )
+            .is_some()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Gt,
+                &serde_json::json!(true)
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn test_build_comparison_expr_array_null_object() {
+        // Non-empty array -> IN.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::In,
+                &serde_json::json!(["a", "b"]),
+            )
+            .is_some()
+        );
+        // Empty array, or an array of only objects (no extractable scalars) -> None.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::In,
+                &serde_json::json!([])
+            )
+            .is_none()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::In,
+                &serde_json::json!([{"k": "v"}]),
+            )
+            .is_none()
+        );
+        // Null + Eq/IsNull -> IS NULL; other operators -> None.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::Value::Null
+            )
+            .is_some()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::IsNull,
+                &serde_json::Value::Null,
+            )
+            .is_some()
+        );
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Gt,
+                &serde_json::Value::Null
+            )
+            .is_none()
+        );
+        // Object value is unsupported -> None.
+        assert!(
+            build_comparison_expr(
+                cmp_entity::Column::Name,
+                FilterOperator::Eq,
+                &serde_json::json!({"k": "v"}),
+            )
+            .is_none()
+        );
     }
 
     /// Test numeric comparison operators
@@ -1085,5 +1359,26 @@ mod tests {
             "Range offset should be capped at {}",
             MAX_OFFSET
         );
+    }
+
+    /// A3 regression: a huge `end` in the range branch must not overflow the `+ 1`
+    /// (which panics under overflow-checks). Should cap cleanly instead.
+    #[test]
+    fn test_pagination_range_huge_end_does_not_overflow() {
+        let params = crate::models::FilterOptions {
+            range: Some(format!("[0,{}]", u64::MAX)),
+            ..Default::default()
+        };
+        let (offset, limit) = parse_pagination(&params);
+        assert!(limit <= MAX_PAGE_SIZE, "limit must be capped, got {limit}");
+        assert!(offset <= MAX_OFFSET, "offset must be capped, got {offset}");
+
+        // Reversed range (end < start) must not panic either.
+        let params = crate::models::FilterOptions {
+            range: Some(format!("[{},{}]", u64::MAX, u64::MAX)),
+            ..Default::default()
+        };
+        let (_offset, limit) = parse_pagination(&params);
+        assert!(limit <= MAX_PAGE_SIZE);
     }
 }

--- a/crudcrate/src/filtering/search.rs
+++ b/crudcrate/src/filtering/search.rs
@@ -8,11 +8,33 @@ const MAX_SEARCH_QUERY_LENGTH: usize = 10_000;
 /// Escape LIKE wildcards to prevent wildcard injection attacks.
 /// Uses `!` as the escape character (declared via `ESCAPE '!'` in the SQL).
 /// Avoids backslash which conflicts with Postgres string quoting.
-fn escape_like_wildcards(input: &str) -> String {
+///
+/// Shared with [`crate::filtering::conditions`] so the LIKE-fallback and joined
+/// `_like` paths use the same escape convention and always pair it with an
+/// explicit `ESCAPE '!'` clause.
+pub(crate) fn escape_like_wildcards(input: &str) -> String {
     input
         .replace('!', "!!")
         .replace('%', "!%")
         .replace('_', "!_")
+}
+
+/// Truncate `s` to at most `max_bytes`, snapping down to the nearest UTF-8 char
+/// boundary so we never slice through a multi-byte codepoint.
+///
+/// A raw `&s[..max_bytes]` panics when `max_bytes` lands inside a multi-byte
+/// character (e.g. an attacker-supplied query of 9_999 ASCII bytes followed by
+/// `é`). `str::floor_char_boundary` would do this but is still unstable, so we
+/// walk back to a boundary manually.
+fn truncate_to_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
 }
 
 /// Build fulltext search condition with database-specific optimizations
@@ -53,7 +75,7 @@ fn build_postgres_fulltext_condition(
         .collect::<Vec<_>>()
         .join(" || ' ' || ");
 
-    let sanitized = query[..query.len().min(MAX_SEARCH_QUERY_LENGTH)].trim();
+    let sanitized = truncate_to_char_boundary(query, MAX_SEARCH_QUERY_LENGTH).trim();
     let pattern = format!("%{}%", escape_like_wildcards(sanitized));
 
     Some(Expr::cust_with_values(
@@ -83,7 +105,7 @@ fn build_mysql_fulltext_condition(
         format!("CONCAT({})", coalesced.join(", ' ', "))
     };
 
-    let sanitized = query[..query.len().min(MAX_SEARCH_QUERY_LENGTH)].trim();
+    let sanitized = truncate_to_char_boundary(query, MAX_SEARCH_QUERY_LENGTH).trim();
     let pattern = format!("%{}%", escape_like_wildcards(sanitized).to_uppercase());
 
     Some(Expr::cust_with_values(
@@ -109,7 +131,7 @@ fn build_fallback_fulltext_condition(
         .collect::<Vec<_>>()
         .join(" || ' ' || ");
 
-    let sanitized = query[..query.len().min(MAX_SEARCH_QUERY_LENGTH)].trim();
+    let sanitized = truncate_to_char_boundary(query, MAX_SEARCH_QUERY_LENGTH).trim();
     let pattern = format!("%{}%", escape_like_wildcards(sanitized).to_uppercase());
 
     Some(Expr::cust_with_values(
@@ -479,5 +501,49 @@ mod tests {
         assert!(build_postgres_fulltext_condition("", &["name"]).is_none());
         assert!(build_mysql_fulltext_condition("", &["name"]).is_none());
         assert!(build_fallback_fulltext_condition("", &["name"]).is_none());
+    }
+
+    /// A2 regression: a query longer than the byte cap whose boundary lands inside
+    /// a multi-byte codepoint must not panic the truncation slice. 9_999 ASCII bytes
+    /// followed by `é` (2 bytes) puts byte index 10_000 inside the `é`.
+    #[test]
+    fn test_fulltext_multibyte_truncation_does_not_panic() {
+        let query = format!("{}é", "a".repeat(MAX_SEARCH_QUERY_LENGTH - 1));
+        assert!(query.len() > MAX_SEARCH_QUERY_LENGTH);
+        // None of these should panic on the byte-index slice.
+        assert!(build_postgres_fulltext_condition(&query, &["name"]).is_some());
+        assert!(build_mysql_fulltext_condition(&query, &["name"]).is_some());
+        assert!(build_fallback_fulltext_condition(&query, &["name"]).is_some());
+    }
+
+    /// `build_like_condition` on Postgres must use the `$1` placeholder, not `?`.
+    /// All other unit tests use SQLite; this covers the Postgres `placeholder_for` arm.
+    #[test]
+    fn test_build_like_condition_postgres_placeholder() {
+        let result = build_like_condition("title", "x", DatabaseBackend::Postgres);
+        let debug = format!("{result:?}");
+        let (template, _values) = split_custom_with_expr(&debug);
+        assert!(
+            template.contains("LIKE $1 ESCAPE '!'"),
+            "Postgres must use $1 placeholder, got: {template}"
+        );
+    }
+
+    /// MySQL single-column fulltext uses a bare `COALESCE(...)` (no `CONCAT`), unlike
+    /// the multi-column path. Exercises the `coalesced.len() == 1` branch.
+    #[test]
+    fn test_mysql_fulltext_single_column_no_concat() {
+        let result = build_mysql_fulltext_condition("hello", &["name"])
+            .expect("non-empty input produces a condition");
+        let debug = format!("{result:?}");
+        let (template, _values) = split_custom_with_expr(&debug);
+        assert!(
+            !template.contains("CONCAT"),
+            "single-column MySQL fulltext should not wrap in CONCAT: {template}"
+        );
+        assert!(
+            template.contains("COALESCE"),
+            "expected COALESCE in template: {template}"
+        );
     }
 }

--- a/crudcrate/src/operations.rs
+++ b/crudcrate/src/operations.rs
@@ -412,10 +412,12 @@ pub trait CRUDOperations: Send + Sync {
                 .map_err(ApiError::database)?;
         }
 
-        // Return only IDs that actually existed (preserving input order)
+        // Return only IDs that actually existed, de-duplicated while preserving input
+        // order — duplicate input ids would otherwise over-report the rows deleted.
+        let mut seen = std::collections::HashSet::new();
         Ok(ids
             .into_iter()
-            .filter(|id| existing_set.contains(id))
+            .filter(|id| existing_set.contains(id) && seen.insert(*id))
             .collect())
     }
 

--- a/crudcrate/src/validation.rs
+++ b/crudcrate/src/validation.rs
@@ -127,14 +127,61 @@ impl std::error::Error for ValidationErrors {}
 /// Trait for types that can be validated
 ///
 /// Implement this trait on your Create/Update models to add custom validation.
-/// The validation will be called automatically before database operations if
-/// you use the generated CRUD handlers.
+/// When you use the generated CRUD handlers (`#[crudcrate(generate_router)]`), the
+/// generated `create`/`create_many`/`update`/`update_many` implementations call
+/// `validate()` automatically before any database write, returning HTTP 422 on
+/// failure. Models that do not implement `Validatable` are unaffected (the
+/// generated check is a no-op for them — see [`__auto`]).
 pub trait Validatable {
     /// Validate the instance.
     ///
     /// # Errors
     /// Returns `Err(ValidationError)` if validation fails.
     fn validate(&self) -> Result<(), ValidationError>;
+}
+
+/// Autoref-specialization machinery used by the derive-generated CRUD handlers to
+/// invoke [`Validatable::validate`] only for models that implement it, with a no-op
+/// fallback otherwise — without requiring nightly `specialization`.
+///
+/// The generated code calls `Probe(&model).crudcrate_auto_validate()`. When the
+/// model implements [`Validatable`], the inherent method on [`Probe`] wins method
+/// resolution and runs the real validation; otherwise the blanket
+/// [`ValidatableFallback`] trait method is used and does nothing.
+#[doc(hidden)]
+pub mod __auto {
+    use super::{Validatable, ValidationError};
+
+    /// No-op fallback implemented for every type. Lower priority than the inherent
+    /// method on `Probe<T: Validatable>`.
+    pub trait ValidatableFallback {
+        /// No-op validation for types that do not implement [`Validatable`].
+        ///
+        /// # Errors
+        /// Never returns an error.
+        fn crudcrate_auto_validate(&self) -> Result<(), ValidationError>;
+    }
+
+    impl<T> ValidatableFallback for T {
+        fn crudcrate_auto_validate(&self) -> Result<(), ValidationError> {
+            Ok(())
+        }
+    }
+
+    /// Wrapper whose inherent method shadows the [`ValidatableFallback`] trait
+    /// method when the wrapped type implements [`Validatable`].
+    pub struct Probe<'a, T>(pub &'a T);
+
+    impl<T: Validatable> Probe<'_, T> {
+        /// Runs the real [`Validatable::validate`]. Selected over the fallback
+        /// because inherent methods take priority in method resolution.
+        ///
+        /// # Errors
+        /// Returns the wrapped type's [`ValidationError`] on failure.
+        pub fn crudcrate_auto_validate(&self) -> Result<(), ValidationError> {
+            self.0.validate()
+        }
+    }
 }
 
 /// Helper validators for common patterns
@@ -151,7 +198,10 @@ pub mod validators {
         min: Option<usize>,
         max: Option<usize>,
     ) -> Result<(), ValidationError> {
-        let len = value.len();
+        // Count Unicode scalar values, not UTF-8 bytes: the messages promise a limit
+        // in "characters", so a multibyte value (accented names, CJK) within the
+        // character limit must not be rejected for exceeding a byte count.
+        let len = value.chars().count();
 
         if let Some(min_len) = min
             && len < min_len
@@ -215,7 +265,7 @@ pub mod validators {
             return Err(ValidationError::new(field, "Invalid email format"));
         }
 
-        if value.len() > 255 {
+        if value.chars().count() > 255 {
             return Err(ValidationError::new(
                 field,
                 "Email must be at most 255 characters",
@@ -276,6 +326,23 @@ mod tests {
 
         // Just right
         assert!(validate_length("name", "abc", Some(3), Some(5)).is_ok());
+    }
+
+    /// A7 regression: limits are in characters, not UTF-8 bytes. "José" is 4 chars
+    /// but 5 bytes, and "日本語" is 3 chars but 9 bytes — both must pass a max of 4/3.
+    #[test]
+    fn test_validate_length_counts_characters_not_bytes() {
+        use validators::validate_length;
+        assert!(
+            validate_length("name", "José", None, Some(4)).is_ok(),
+            "4-char multibyte value must pass a 4-char max"
+        );
+        assert!(
+            validate_length("name", "日本語", Some(3), Some(3)).is_ok(),
+            "3-char CJK value must satisfy a 3-char min/max"
+        );
+        // And a genuinely-too-long multibyte value is still rejected.
+        assert!(validate_length("name", "Joséé", None, Some(4)).is_err());
     }
 
     #[test]


### PR DESCRIPTION
First of a series recovering test coverage and fixing issues surfaced by a full audit of the library. This PR contains the **behavioural fixes** (the judgment calls); the broader test/coverage additions, example cleanups, integer-PK support, and multi-backend CI coverage follow in separate PRs.

## Fixes

- **LIKE escaping was a no-op on SQLite.** `conditions.rs` escaped wildcards with backslash and fed `sea_query .like()`, which emits no `ESCAPE` clause — so user-supplied `%`/`_` stayed live wildcards on the fulltext LIKE-fallback path and joined `_like` filters. Unified on the `search.rs` `!`-escaper and emit an explicit `ESCAPE '!'` clause on every `.like()` (via `LikeExpr::escape`).
- **Attacker-reachable panic in fulltext truncation.** The three builders sliced `query[..min(len, 10_000)]`, which panics when byte 10_000 lands mid-codepoint. Added a char-boundary-safe truncation helper.
- **Range-pagination overflow.** `(end.saturating_sub(start) + 1)` overflowed on `range=[0,u64::MAX]` (panic under overflow-checks). Now uses `saturating_add`.
- **`delete_many` over-reported deletions** for duplicated input ids — now de-duplicated while preserving order (trait default, derive codegen, and `CRUDOperations`).
- **Scoped `get_one` masked all errors as 404**, hiding DB/internal faults from monitoring. Now propagates the real error (scope-miss already returns 404).
- **Partial batch-delete leaked row existence under the default secure profile** via per-item not-found messages embedding UUIDs. The secure response now reports `failed_count` instead of the verbatim `failed` list.
- **Validation length/email used byte length, not character count**, wrongly rejecting multibyte input within the advertised character limit.
- **Duplicate-key inserts returned 500, not the documented 409.** `ApiError::database` now maps `SqlErr::UniqueConstraintViolation` to 409 Conflict (the insert path bypasses the `From<DbErr>` impl).
- **`Validatable` is now actually invoked.** Its docs promised automatic validation but nothing called it. Generated `create`/`create_many`/`update`/`update_many` now run `validate()` before any write — via autoref specialization, so it's a no-op for models that don't implement the trait (no nightly `specialization`, no opt-in attribute).
- **Aligned batch-create response shape.** `POST /batch` (all-or-nothing) and `POST /batch?partial=true` returned differently-shaped items (flat vs join-loaded/transformed). Partial now uses `create_many` per item so both modes return the same flat shape and run the same `create::many` hooks.

## Tests

Unit regression tests added for the function-level fixes: a full `build_comparison_expr` suite (incl. the LIKE `ESCAPE '!'` regression), multibyte truncation, Postgres placeholder + MySQL single-column fulltext, range overflow, and character-count validation. Integration regression tests (secure partial-delete, 409, auto-validate, batch-create shape) land with the coverage PR.

Full suite: 611 passed, 0 failed locally (`--test-threads=1`).